### PR TITLE
Speed up reference usage and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ By default `fake-vcf` writes to stdout
 ```shell
 poetry run fake-vcf generate -s 2 -r 2
 ##fileformat=VCFv4.2
-##source=VCFake 0.2.0
+##source=VCFake 0.2.1
 ##FILTER=<ID=PASS,Description="All filters passed">
 ##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of Samples With Data">
 ##contig=<ID=chr1>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,7 @@
 project = "fake-vcf"
 copyright = "2023, Magnus Wahlberg"
 author = "Magnus Wahlberg"
-version = "0.2.0"
+version = "0.2.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -25,7 +25,7 @@ By default `fake-vcf` writes to stdout
 
   poetry run fake-vcf generate -s 2 -r 2
   ##fileformat=VCFv4.2
-  ##source=VCFake 0.2.0
+  ##source=VCFake 0.2.1
   ##FILTER=<ID=PASS,Description="All filters passed">
   ##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of Samples With Data">
   ##contig=<ID=chr1>

--- a/fake_vcf/vcf_faker.py
+++ b/fake_vcf/vcf_faker.py
@@ -136,7 +136,9 @@ class VirtualVCF:
 
         self.reference_data = None
         if self.reference_dir:
-            self.reference_data = vcf_reference.load_reference_data(self.reference_file)
+            self.reference_data = vcf_reference.load_reference_data(
+                self.reference_file, memory_map=False
+            )
             if self.reference_data.shape[0] < max(self.positions):
                 raise ValueError(
                     f"""Max position size {max(self.positions)} is outside the reference which has a max of {len(self.reference_data)}"""

--- a/fake_vcf/vcf_reference.py
+++ b/fake_vcf/vcf_reference.py
@@ -10,12 +10,12 @@ import fake_vcf
 METADATA_FILE_NAME = "sequence_metadata.json"
 
 
-def get_ref_at_pos(ref_data, position):
-    reference_value = ref_data.take([position])[0][0].as_py()
+def get_ref_at_pos(ref_data: pa.array, position):
+    reference_value = ref_data.column(0)[position].as_py()
     return reference_value
 
 
-def load_reference_data(reference_file, memory_map=True):
+def load_reference_data(reference_file, memory_map):
     reference_data = pq.read_table(reference_file, memory_map=memory_map)
     return reference_data
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "fake-vcf"
-version = "0.2.0"
+version = "0.2.1"
 description = "A fake vcf file generator "
 readme = "README.md"
 authors = ["fake-vcf <endast@gmail.com>"]

--- a/tests/test_data/chr1_small.vcf
+++ b/tests/test_data/chr1_small.vcf
@@ -1,5 +1,5 @@
 ##fileformat=VCFv4.2
-##source=VCFake 0.2.0
+##source=VCFake 0.1.0
 ##FILTER=<ID=PASS,Description="All filters passed">
 ##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of Samples With Data">
 ##contig=<ID=chr1>

--- a/tests/test_data/chr2_small.vcf
+++ b/tests/test_data/chr2_small.vcf
@@ -1,5 +1,5 @@
 ##fileformat=VCFv4.2
-##source=VCFake 0.2.0
+##source=VCFake 0.2.1
 ##FILTER=<ID=PASS,Description="All filters passed">
 ##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of Samples With Data">
 ##contig=<ID=chr2>

--- a/tests/test_data/reference/parquet/sequence_metadata.json
+++ b/tests/test_data/reference/parquet/sequence_metadata.json
@@ -1,6 +1,6 @@
 {
   "source_reference_file": "test-reference.fa",
-  "fake-vcf-version": "0.2.0",
+  "fake-vcf-version": "0.2.1",
   "reference_files": {
     "chr1": "fasta_chr1.parquet",
     "chr2": "fasta_chr2.parquet",


### PR DESCRIPTION
## Description

Speeds up generation when using a reference fasta file.

### fake-vcf version: 0.2.0

```
fake-vcf generate -r 100 -s 1000 -o /tmp/dump.vcf
...
299 ms ± 6.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

```
fake-vcf generate -r 100 -s 1000 -o /tmp/dump.vcf --reference-dir-path reference_dir
...
13.4 s ± 56.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
### fake-vcf version: 0.2.1
```
fake-vcf generate -r 100 -s 1000 -o /tmp/dump.vcf
...
306 ms ± 5.62 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

```
fake-vcf generate -r 100 -s 1000 -o /tmp/dump.vcf
...
1.41 s ± 9.23 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```


## Related Issue

[Original issue](https://github.com/endast/fake-vcf/issues/232)


## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [X] 🔧 Bug fix (non-breaking change which fixes an issue)
- [X] 🥂 Improvement (non-breaking change which improves an existing feature)

