### PR TITLE
fixed off-by-one in reference allele retrieval

### DIFF
--- a/fake_vcf/vcf_faker.py
+++ b/fake_vcf/vcf_faker.py
@@ -192,7 +192,7 @@ class VirtualVCF:
         """
         if self.reference_data:
             reference_value = vcf_reference.get_ref_at_pos(
-                self.reference_data, position
+                self.reference_data, position - 1
             )
         else:
             reference_value = self.alleles[ref_index]


### PR DESCRIPTION
## What
Fetching the reference allele from a previously created reference underlied a off-by-one mistake, in which the allele after the seeked position was returned. This is fixed in this PR. 

## Related Issue

when normalizing the created vcf files using `bcftools norm`, a missmatch error was returned, e.g. `Reference allele mismatch at chr4:10023 .. REF_SEQ:'T' vs VCF:'A` before. This is fixed with this update

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/fake_vcf/fake-vcf/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/endast/fake-vcf/blob/main/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in sphinx format for all the methods and classes that I used.
